### PR TITLE
IDEA-306713: Unable to use Error Prone Compiler

### DIFF
--- a/error-prone/resources/library/error-prone.xml
+++ b/error-prone/resources/library/error-prone.xml
@@ -3,7 +3,7 @@
   <artifact version="2.16.0" name="error-prone">
     <item url="https://repo1.maven.org/maven2/com/google/errorprone/error_prone_core/2.16/error_prone_core-2.16-with-dependencies.jar"/>
     <item url="https://repo1.maven.org/maven2/com/google/code/findbugs/jFormatString/3.0.0/jFormatString-3.0.0.jar"/>
-    <item url="https://repo1.maven.org/maven2/org/checkerframework/dataflow-shaded/3.24.0/dataflow-shaded-3.24.0.jar"/>
+    <item url="https://repo1.maven.org/maven2/org/checkerframework/dataflow-errorprone/3.24.0/dataflow-errorprone-3.24.0.jar"/>
     <item url="https://repo1.maven.org/maven2/com/google/errorprone/javac/9+181-r4173-1/javac-9+181-r4173-1.jar"/>
   </artifact>
 </artifacts>


### PR DESCRIPTION
Fix of IDEA-306713: Unable to use 'Error Prone Compiler' due to NoClassDefFoundError

Incorrect dataflow artifact is using, should be used dataflow-errorprone, since 3.14 version